### PR TITLE
Added missing include, reduces ARINC653 includes, exposed prcs_info_t

### DIFF
--- a/a653_inc/a653Init.h
+++ b/a653_inc/a653Init.h
@@ -27,10 +27,10 @@
  * @details 
  */
 
-#include <sys/types.h>
-
 #ifndef __A653INIT_H__
 #define __A653INIT_H__
+
+#include "a653Type.h"
 
 //#define S_TRACE 1
 //#define S_DEBUG 1
@@ -70,7 +70,7 @@ typedef struct {
   int core_number;
   int partition_number;
   int time_slice_number;
-  int64_t time_slice_size; /* value in nsec */
+  A653_LONG_INTEGER time_slice_size; /* value in nsec */
   a653_partition_entry_t partition[MAX_PARTITION];
   a653_time_slice_config_t time_slice[MAX_TIME_SLICE_NUM][MAX_CORE_NUM];
   int magic;

--- a/a653_inc/a653Lib.h
+++ b/a653_inc/a653Lib.h
@@ -30,17 +30,6 @@
 #ifndef __A653_LIB_H
 #define __A653_LIB_H
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-//--------------------
-#include <errno.h>
-#include <pthread.h>
-#include <unistd.h>
-#include <signal.h>
-
-#include <sys/shm.h>
-
 /* a653 includes */
 #include <a653Type.h>
   //#include <a653Blackboard.h>

--- a/a653_inc/a653Partition.h
+++ b/a653_inc/a653Partition.h
@@ -8,6 +8,8 @@
 #ifndef A653_PARTITION
 #define A653_PARTITION
 
+#include "a653Type.h"
+
 typedef enum {
   IDLE = 0,
   COLD_START = 1,

--- a/a653_inc/a653Semaphore.h
+++ b/a653_inc/a653Semaphore.h
@@ -31,6 +31,8 @@
 #ifndef A653_SEMAPHORE
 #define A653_SEMAPHORE
 
+#include "a653Type.h"
+
 #define MAX_NUMBER_OF_SEMAPHORES MAX_SEM_NUM
 
 #define MAX_SEMAPHORE_VALUE 32767

--- a/a653_lib/a653_i_partition.c
+++ b/a653_lib/a653_i_partition.c
@@ -59,7 +59,7 @@ int own_partition_idx;
 int64_t time_slice;
 a653_partition_config_t own_partition_config;
 
-/* do not call main schaduler !!!!!! */
+/* do not call main scheduler !!!!!! */
 int a653_init_partition(void){
   
   int ret_val = 0;

--- a/a653_lib/a653_i_partition.c
+++ b/a653_lib/a653_i_partition.c
@@ -30,6 +30,7 @@
 /* includes */
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>

--- a/a653_lib/a653_i_process.c
+++ b/a653_lib/a653_i_process.c
@@ -33,8 +33,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <time.h>
-#include <pthread.h>
 #include <semaphore.h>
 
 #define A653_QUEUING_INTERN

--- a/a653_lib/a653_i_process.c
+++ b/a653_lib/a653_i_process.c
@@ -55,21 +55,6 @@
 
 #define PRCS_START_ID 1
 
-typedef struct {
-  //  PROCESS_ATTRIBUTE_TYPE attr;
-  
-  pthread_mutex_t        t_lock;
-  pthread_t              t_ctx;
-  pthread_attr_t         t_attr;
-  int64_t                timerPeriod;
-  struct timespec        nextActivation;
-  unsigned int           priority;
-  unsigned int           cycle_cnt;
-  unsigned short         id;
-  char                   name[35];
-  func_ptr               prcs_main_func;
-} prcs_info_t;
-
 extern a653_shm_info_t *shm_ptr;
 extern int own_partition_idx;
 extern int64_t time_slice;

--- a/a653_lib/a653_i_process.h
+++ b/a653_lib/a653_i_process.h
@@ -30,6 +30,10 @@
 #ifndef __A653_I_PARTITION_H__
 #define __A653_I_PARTITION_H__
 
+#include <pthread.h>
+#include <stdint.h>
+#include <time.h>
+
 #include "a653Type.h"
 #include "a653Error.h"
 #include "a653Process.h"

--- a/a653_lib/a653_i_process.h
+++ b/a653_lib/a653_i_process.h
@@ -40,6 +40,21 @@
 typedef void *(*__start_routine) (void *);
 typedef void (*func_ptr)(void);
 
+typedef struct {
+  //  PROCESS_ATTRIBUTE_TYPE attr;
+ 
+  pthread_mutex_t        t_lock;
+  pthread_t              t_ctx;
+  pthread_attr_t         t_attr;
+  int64_t                timerPeriod;
+  struct timespec        nextActivation;
+  unsigned int           priority;
+  unsigned int           cycle_cnt;
+  unsigned short         id;
+  char                   name[35];
+  func_ptr               prcs_main_func;
+} prcs_info_t;
+
 
 void a653_act_prcs(void);
 

--- a/main.c
+++ b/main.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <signal.h>
 //--------------------
@@ -92,8 +93,8 @@ int main (int argc, char *argv[]){
   
   setDebug(3);
 
-  time ( &rawtime );
-  timeinfo = localtime ( &rawtime );
+  time ( (time_t*)&rawtime );
+  timeinfo = localtime ( (const time_t*)&rawtime );
   printDebug(0,"Current local time and date: %s", asctime (timeinfo) );
 
   a653_i_init_sync();


### PR DESCRIPTION
For later usage, this fixes:
- Added missing include a653Type.h
- Moved the prcs_info_t definition into the internal a653_i_process.h
- Removed exposure of standard includes within ARINC653 headers.