### PR TITLE
Bugfix for CREATE_PROCESS

### DIFF
--- a/a653_lib/a653_i_process.c
+++ b/a653_lib/a653_i_process.c
@@ -95,7 +95,7 @@ int a653_prcs_init(void){
 
   int ret_val = 0;
 
-  prcs_info = (prcs_info_t *) malloc(sizeof(prcs_info_t) * MAX_PRCS);
+  prcs_info = (prcs_info_t *) calloc(MAX_PRCS, sizeof(prcs_info_t));
   prcsHash = (int *) malloc(sizeof(int) *(PRCS_START_ID + MAX_PRCS));
   
   if ((prcs_info != NULL) &&
@@ -257,7 +257,7 @@ void CREATE_PROCESS (PROCESS_ATTRIBUTE_TYPE *ATTRIBUTES,
 
   *RETURN_CODE = INVALID_CONFIG;
 
-  while ((number_of_processes < MAX_PRCS)) {
+  while ((number_of_processes < MAX_PRCS && idx < MAX_PRCS)) {
     if (prcs_info[idx].id == 0) {
       number_of_processes++;
       prcs_info[idx].id = prcs_id_next++;


### PR DESCRIPTION
Due to the fact that prcs_info becomes malloced, it might be that initial data is not 0. However, `CREATE_PROCESS` tries to search for a `prcs_info[idx].id` which shall be 0. In the worst case, this won't happen. Since `idx` is also not checked against `MAX_PRCS`, the `idx` can be way out of the malloced reachen. And thus, accessing something it shouldn't access.